### PR TITLE
大佬，发现您的项目引入了com.h2database:h2@1.4.199组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -54,7 +53,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.199</version>
+            <version>2.1.210</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：com.h2database:h2 < 2.0.202 XXE漏洞
缺陷组件：com.h2database:h2@1.4.199
漏洞编号：CVE-2021-23463
漏洞描述：H2是java开发的嵌入式数据库。
com.h2database:h2 在1.4.198至1.4.200 的版本中，org.h2.jdbc.JdbcSQLXML类存在XML实体注入漏洞。
漏洞原因：
使用org.h2.jdbc.JdbcResultSet.getSQLXML方法获得解析字符串时，如果getSource方法的参数为DOMSource.class则会导致恶意注入。
影响范围：[1.4.198, 2.0.202)
最小修复版本：2.1.210
缺陷组件引入路径：ru.ezhov:general-service@0.0.1-SNAPSHOT->com.h2database:h2@1.4.199
```
另外我运行这个项目时，IDE的安全插件提示还有68个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pec6bf